### PR TITLE
Fix: Sotetseg hide white screen timing to maze phase only - improves TOB Mistake Tracker Plugin death detection

### DIFF
--- a/src/main/java/com/tobqol/TheatreQOLPlugin.java
+++ b/src/main/java/com/tobqol/TheatreQOLPlugin.java
@@ -409,11 +409,11 @@ public class TheatreQOLPlugin extends Plugin
 			instanceService.setPreviousRegion(instanceService.getCurrentRegion());
 		}
 
-		if (((isInVerSinhaza() && config.lightUp()) || (isInSotetseg() && config.hideSotetsegWhiteScreen())) && !darknessHidden)
+		if (((isInVerSinhaza() && config.lightUp()) || (instanceService.getCurrentRegion().isSotetsegUnderworld() && config.hideSotetsegWhiteScreen())) && !darknessHidden)
 		{
 			hideDarkness(true);
 		}
-		else if ((!isInVerSinhaza() && !isInSotetseg()) && darknessHidden)
+		else if ((!isInVerSinhaza() && !instanceService.getCurrentRegion().isSotetsegUnderworld()) && darknessHidden)
 		{
 			hideDarkness(false);
 		}


### PR DESCRIPTION
The 'Hide White Screen' toggle would break the TOB Mistake Tracker plugin's death detection for Sotetseg - making it so deaths inside the room would not be tracked when the setting is enabled. This change allows the TOB Mistake Tracker plugin to detect the Sotetseg room so it can properly count player deaths within the room when the Hide White Screen toggle is enabled.